### PR TITLE
Handle client payload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ on:
         required: false
         default: 'woarm64'
 env:
-  BINUTILS_BRANCH: ${{ github.event.inputs.binutils-branch }}
-  GCC_BRANCH: ${{ github.event.inputs.gcc-branch }}
-  MINGW_BRANCH: ${{ github.event.inputs.mingw-branch }}
+  BINUTILS_BRANCH: ${{ github.event.inputs.binutils-branch || github.event.client_payload.binutils_branch }}
+  GCC_BRANCH: ${{ github.event.inputs.gcc-branch || github.event.client_payload.gcc_branch }}
+  MINGW_BRANCH: ${{ github.event.inputs.mingw-branch || github.event.client_payload.mingw_branch }}
 
 jobs:
   run-script:


### PR DESCRIPTION
This should handle branch names in client payload of the workflow_dispatch event coming from https://github.com/ZacWalk/gcc-woarm64/pull/2 but it's not tested/finished yet.