### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 build-aarch64-w64-mingw32/
 code/
 downloads/


### PR DESCRIPTION
Adds .vscode to .gitignore and fixes missing end-line at the end of the .gitignore file.