### PR TITLE
Refactor installation job to be consistent with build.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,11 @@ jobs:
         
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install -y build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpc-dev
+          ./install-dependencies.sh
 
       - name: Run Bash Script
         run: |
-          chmod +x ./build.sh
-          bash ./build.sh
+          ./build.sh
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -e # stop at first error
+set -x # echo on
+
+echo "::group::Install Dependencies"
+sudo apt update
+sudo apt install -y build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpc-dev
+echo "::endgroup::"
+
+echo 'Success!'


### PR DESCRIPTION
This makes build and installation jobs of the GHA workflow somewhat consistent.