### PR TITLE
Add other build variants

### DIFF
--- a/.github/scripts/build-mingw-crt.sh
+++ b/.github/scripts/build-mingw-crt.sh
@@ -3,9 +3,28 @@
 MINGW_VERSION=${MINGW_VERSION:-mingw-w64-master}
 
 TARGET=${TARGET:-aarch64-w64-mingw32}
+CRT=${CRT:-msvcrt}
 BUILD_PATH=${BUILD_PATH:-$PWD/build-$TARGET}
 BUILD_MAKE_OPTIONS=-j$(nproc)
 INSTALL_PATH=${INSTALL_PATH:-~/cross}
+
+case "$TARGET" in
+    x86_64*)
+        MINGW_CONF="$MINGW_CONF --disable-lib32 --enable-lib64 --disable-libarm32 --disable-libarm64"
+    ;;
+    aarch64*)
+        MINGW_CONF="$MINGW_CONF --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+    ;;
+esac
+
+case "$CRT" in
+    ucrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=ucrt"
+    ;;
+    msvcrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=msvcrt"
+    ;;
+esac
 
 export PATH=$INSTALL_PATH/bin:$PATH
 
@@ -21,12 +40,8 @@ echo "::group::Configure MinGW CRT"
     --build=x86_64-linux-gnu \
     --host=$TARGET \
     --with-sysroot=$INSTALL_PATH \
-    --enable-libarm64 \
-    --disable-lib32 \
-    --disable-lib64 \
-    --disable-libarm32 \
     --disable-shared \
-    --with-default-msvcrt=msvcrt
+    $MINGW_CONF
 echo "::endgroup::"
 
 cd $BUILD_PATH/mingw

--- a/.github/scripts/build-mingw-headers.sh
+++ b/.github/scripts/build-mingw-headers.sh
@@ -3,9 +3,19 @@
 MINGW_VERSION=${MINGW_VERSION:-mingw-w64-master}
 
 TARGET=${TARGET:-aarch64-w64-mingw32}
+CRT=${CRT:-msvcrt}
 BUILD_PATH=${BUILD_PATH:-$PWD/build-$TARGET}
 BUILD_MAKE_OPTIONS=-j$(nproc)
 INSTALL_PATH=${INSTALL_PATH:-~/cross}
+
+case "$CRT" in
+    ucrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=ucrt"
+    ;;
+    msvcrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=msvcrt"
+    ;;
+esac
 
 export PATH=$INSTALL_PATH/bin:$PATH
 
@@ -19,7 +29,7 @@ echo "::group::Configure MinGW headers"
 ../../code/$MINGW_VERSION/mingw-w64-headers/configure \
     --prefix=$INSTALL_PATH/$TARGET \
     --host=$TARGET \
-    --with-default-msvcrt=msvcrt
+    $MINGW_CONF
 echo "::endgroup::"
 
 cd $BUILD_PATH/mingw-headers

--- a/.github/scripts/build-mingw.sh
+++ b/.github/scripts/build-mingw.sh
@@ -3,9 +3,28 @@
 MINGW_VERSION=${MINGW_VERSION:-mingw-w64-master}
 
 TARGET=${TARGET:-aarch64-w64-mingw32}
+CRT=${CRT:-msvcrt}
 BUILD_PATH=${BUILD_PATH:-$PWD/build-$TARGET}
 BUILD_MAKE_OPTIONS=-j$(nproc)
 INSTALL_PATH=${INSTALL_PATH:-~/cross}
+
+case "$TARGET" in
+    x86_64*)
+        MINGW_CONF="$MINGW_CONF --disable-lib32 --enable-lib64 --disable-libarm32 --disable-libarm64"
+    ;;
+    aarch64*)
+        MINGW_CONF="$MINGW_CONF --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+    ;;
+esac
+
+case "$CRT" in
+    ucrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=ucrt"
+    ;;
+    msvcrt)
+        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=msvcrt"
+    ;;
+esac
 
 export PATH=$INSTALL_PATH/bin:$PATH
 
@@ -18,14 +37,9 @@ echo "::group::Configure MinGW libraries"
 ../../code/$MINGW_VERSION/configure \
     --prefix=$INSTALL_PATH/$TARGET \
     --host=$TARGET \
-    --enable-libarm64 \
-    --disable-lib32 \
-    --disable-lib64 \
-    --disable-libarm32 \
     --disable-shared \
     --with-libraries=libmangle,pseh,winpthreads \
-    --with-default-msvcrt=msvcrt
-
+    $MINGW_CONF
 echo "::endgroup::"
 
 cd $BUILD_PATH/mingw

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -4,6 +4,7 @@ set -e # exit on error
 set -x # echo on
 
 export TARGET=${TARGET:-aarch64-w64-mingw32}
+export CRT=${CRT:-msvcrt}
 export INSTALL_PATH=${INSTALL_PATH:-~/cross}
 
 .github/scripts/build-binutils.sh

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -26,6 +26,11 @@ jobs:
   build-toolchain:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        target: [aarch64-w64-mingw32, x86_64-w64-mingw32]
+        crt: [msvcrt, ucrt]
+
     env:
       BINUTILS_REPO: ZacWalk/binutils-woarm64
       BINUTILS_BRANCH: ${{ github.event.inputs.binutils_branch }}
@@ -36,7 +41,8 @@ jobs:
       MINGW_REPO: ZacWalk/mingw-woarm64
       MINGW_BRANCH: ${{ github.event.inputs.mingw_branch }}
       MINGW_VERSION: mingw-w64-master
-      TARGET: aarch64-w64-mingw32
+      TARGET: ${{ matrix.target }}
+      CRT: ${{ matrix.crt }}
       INSTALL_PATH: ${{ github.workspace }}/cross
 
     steps:
@@ -105,6 +111,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.TARGET }}-toolchain
+          name: ${{ env.TARGET }}-${{ env.CRT }}-toolchain
           path: ${{ env.INSTALL_PATH }}
           retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
-build-aarch64-w64-mingw32/
+build-*/
 code/
 downloads/
 *.exe


### PR DESCRIPTION
Adds `x86_64-w64-mingw32` and `ucrt` builds.

Depends on #39 that needs to be merged first.

Closes https://github.com/ZacWalk/mingw-woarm64-build/issues/36, https://github.com/ZacWalk/mingw-woarm64-build/issues/22